### PR TITLE
Ncsd 3987 add draftcontent

### DIFF
--- a/DFC.Api.Content/OpenAPIDocs/GetDraftContentOpenApi.txt
+++ b/DFC.Api.Content/OpenAPIDocs/GetDraftContentOpenApi.txt
@@ -1,0 +1,90 @@
+openapi: 3.0.1
+info:
+  title: DFC Content API
+  description: 'Retrieves content by Content Type / Id'
+  version: 1.0.0
+servers:
+- url: __FunctionAppUrl__
+tags:
+- name: Get Content
+  description: Returns content by Content Type and Id
+paths:
+  /api/Execute/{contentType}:
+    get:
+      tags:
+      - Content
+      summary: Get all of a particular content type.
+      parameters:
+        - in: path
+          name: contentType
+          schema:
+            type: string
+          required: true
+      description: Returns all of a particular content type.
+      operationId: GetAllByContentType
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/DynamicResponse'
+        204:
+          description: No content can be found.
+          content: {}
+        400:
+          description: Missing data from body or parameters have not been supplied for query.
+          content: {}
+        404:
+          description: Resource not found
+          content: {}
+        422:
+          description: Unprocessable Entity - Unable to read/deserialize data.
+          content: {}
+        500:
+          description: Missing App Settings or Config Files.
+          content: {}
+  /api/Execute/{contentType}/{id}:
+    get:
+      tags:
+      - Content
+      summary: Get Content by Content Type and Id.
+      parameters:
+        - in: path
+          name: contentType
+          schema:
+            type: string
+          required: true
+        - in: path
+          name: id
+          schema:
+            type: string
+          required: true
+      description: Returns a specific instance of a content type.
+      operationId: GetByContentTypeAndId
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/json; charset=utf-8:
+              schema:
+                $ref: '#/components/schemas/DynamicResponse'
+        204:
+          description: No content can be found.
+          content: {}
+        400:
+          description: Missing data from body or parameters have not been supplied for query.
+          content: {}
+        404:
+          description: Resource not found
+          content: {}
+        422:
+          description: Unprocessable Entity - Unable to read/deserialize data.
+          content: {}
+        500:
+          description: Missing App Settings or Config Files.
+          content: {}
+components:
+  schemas:
+    DynamicResponse: 
+      type: "object"

--- a/DFC.Api.Content/OpenAPIDocs/GetDraftContentOpenApi.txt
+++ b/DFC.Api.Content/OpenAPIDocs/GetDraftContentOpenApi.txt
@@ -1,6 +1,6 @@
 openapi: 3.0.1
 info:
-  title: DFC Content API
+  title: DFC Draft Content API
   description: 'Retrieves content by Content Type / Id'
   version: 1.0.0
 servers:

--- a/Resources/ArmTemplates/parameters.json
+++ b/Resources/ArmTemplates/parameters.json
@@ -14,6 +14,15 @@
     "Neo4jPassword": {
       "value": "__Neo4jPassword__"
     },
+    "Neo4jUrlDraft": {
+      "value": "__Neo4jUrlDraft__"
+    },
+    "Neo4jUserDraft": {
+      "value": "__Neo4jUserDraft__"
+    },
+    "Neo4jPasswordDraft": {
+      "value": "__Neo4jPasswordDraft__"
+    },
     "appSharedStorageAccountName": {
       "value": "__appSharedStorageAccountName__"
     },

--- a/Resources/ArmTemplates/parameters.json
+++ b/Resources/ArmTemplates/parameters.json
@@ -2,6 +2,9 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "Environment": {
+      "value": "__ReleaseEnvironmentName__"
+    },
     "Neo4jUrl": {
       "value": "__Neo4jUrl__"
     },
@@ -26,6 +29,9 @@
     "FunctionAppInsightName": {
       "value": "__FunctionAppInsightName__"
     },
+    "FunctionAppInsightNameDraft": {
+      "value": "__FunctionAppInsightNameDraft__"
+    },
     "aspSize": {
       "value": "__aspSize__"
     },
@@ -37,6 +43,9 @@
     },
     "FunctionAppName": {
       "value": "__FunctionAppName__"
+    },
+    "FunctionAppNameDraft": {
+      "value": "__FunctionAppNameDraft__"
     },
     "ApimProductInstanceName": {
       "value": "__ApimProductInstanceName__"

--- a/Resources/ArmTemplates/parameters.json
+++ b/Resources/ArmTemplates/parameters.json
@@ -65,12 +65,6 @@
     "ApiName": {
       "value": "__ApiName__"
     },
-    "ApiVersionNumber": {
-      "value": "__ApiVersion__"
-    },
-    "ApimLoggerName": {
-      "value": "__ApimLoggerName__"
-    },
     "ApimServiceName": {
       "value": "__ApimServiceName__"
     }

--- a/Resources/ArmTemplates/template.json
+++ b/Resources/ArmTemplates/template.json
@@ -2,6 +2,9 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "Environment": {
+      "type": "string"
+    },
     "appSharedResourceGroup": {
       "type": "string"
     },
@@ -21,6 +24,9 @@
     "FunctionAppInsightName": {
       "type": "string"
     },
+    "FunctionAppInsightNameDraft": {
+      "type": "string"
+    },
     "sharedAppServicePlanName": {
       "type": "string"
     },
@@ -28,6 +34,9 @@
       "type": "string"
     },
     "FunctionAppName": {
+      "type": "string"
+    },
+    "FunctionAppNameDraft": {
       "type": "string"
     },
     "ApimProductInstanceName": {
@@ -42,12 +51,6 @@
     "ApiName": {
       "type": "string"
     },
-    "ApiVersionNumber": {
-      "type": "string"
-    },
-    "ApimLoggerName": {
-      "type": "string"
-    },
     "ContentTypeUriMap": {
       "type": "string"
     },
@@ -59,13 +62,22 @@
     },
     "Neo4jPassword": {
       "type": "securestring"
+    },
+    "Neo4jUrlDraft": {
+      "type": "string"
+    },
+    "Neo4jUserDraft": {
+      "type": "string"
+    },
+    "Neo4jPasswordDraft": {
+      "type": "securestring"
     }
   },
   "variables": {
     "appServicePlanName": "[if(greater(length(parameters('sharedAppServicePlanName')), 0), parameters('sharedAppServicePlanName'), concat(variables('resourcePrefix'), '-asp'))]",
     "appServicePlanResourceGroup": "[if(greater(length(parameters('SharedAppServicePlanResourceGroup')), 0), parameters('SharedAppServicePlanResourceGroup'), resourceGroup().name)]",
     "buildingBlocksDfcBaseUrl": "https://raw.githubusercontent.com/SkillsFundingAgency/dfc-devops/master/ArmTemplates/",
-    "resourcePrefix": "[tolower(concat('dfc-dev-api-content'))]",
+    "ResourcePrefix": "[tolower(concat('dfc-', parameters('Environment'), '-api-content'))]",
     "VersionSetName": "[concat(toLower(parameters('ApiName')), '-versionset')]"
   },
   "resources": [
@@ -193,6 +205,26 @@
     },
     {
       "apiVersion": "2017-05-10",
+      "name": "[parameters('FunctionAppInsightNameDraft')]",
+      "type": "Microsoft.Resources/deployments",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('buildingBlocksDfcBaseUrl'), 'application-insights.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "appInsightsName": {
+            "value": "[parameters('FunctionAppInsightNameDraft')]"
+          },
+          "attachedService": {
+            "value": ""
+          }
+        }
+      }
+    },
+    {
+      "apiVersion": "2017-05-10",
       "name": "[parameters('FunctionAppName')]",
       "type": "Microsoft.Resources/deployments",
       "properties": {
@@ -288,6 +320,105 @@
       },
       "dependsOn": [
         "[parameters('FunctionAppInsightName')]"
+      ]
+    },
+    {
+      "apiVersion": "2017-05-10",
+      "name": "[parameters('FunctionAppNameDraft')]",
+      "type": "Microsoft.Resources/deployments",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('buildingBlocksDfcBaseUrl'), 'app-service.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "appServiceName": {
+            "value": "[parameters('FunctionAppNameDraft')]"
+          },
+          "appServicePlanName": {
+            "value": "[variables('appServicePlanName')]"
+          },
+          "appServicePlanResourceGroup": {
+            "value": "[variables('appServicePlanResourceGroup')]"
+          },
+          "appServiceType": {
+            "value": "functionapp"
+          },
+          "deployStagingSlot": {
+            "value": true
+          },
+          "clientAffinity": {
+            "value": true
+          },
+          "appServiceAppSettings": {
+            "value": [
+              {
+                "name": "FUNCTIONS_EXTENSION_VERSION",
+                "value": "~3"
+              },
+              {
+                "name": "FUNCTIONS_WORKER_RUNTIME",
+                "value": "dotnet"
+              },
+              {
+                "name": "MSDEPLOY_RENAME_LOCKED_FILES",
+                "value": "1"
+              },
+              {
+                "name": "WEBSITE_RUN_FROM_PACKAGE",
+                "value": "1"
+              },
+              {
+                "name": "AzureWebJobsStorage",
+                "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',parameters('appSharedStorageAccountName'),';AccountKey=',listKeys(resourceId(parameters('appSharedResourceGroup'), 'Microsoft.Storage/storageAccounts', parameters('appSharedStorageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value, ';EndpointSuffix=core.windows.net')]"
+              },
+              {
+                "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
+                "value": "[reference(parameters('FunctionAppInsightNameDraft')).outputs.InstrumentationKey.value]"
+              },
+              {
+                "name": "ContentType__ContentTypeUriMap__occupation",
+                "value": "[concat(parameters('ContentTypeUriMap'), '/occupation/{0}')]"
+              },
+              {
+                "name": "ContentType__ContentTypeUriMap__skill",
+                "value": "[concat(parameters('ContentTypeUriMap'), '/skill/{0}')]"
+              },
+              {
+                "name": "ContentType__ContentTypeNameMap__occupation",
+                "value": "esco__occupation"
+              },
+              {
+                "name": "ContentType__ContentTypeNameMap__skill",
+                "value": "esco__skill"
+              },
+              {
+                "name": "ContentType__scheme",
+                "value": "https"
+              },
+              {
+                "name": "Neo4j__Endpoints__0__Enabled",
+                "value": "true"
+              },
+              {
+                "name": "Neo4j__Endpoints__0__Uri",
+                "value": "[parameters('Neo4jUrlDraft')]"
+              },
+              {
+                "name": "Neo4j__Endpoints__0__Username",
+                "value": "[parameters('Neo4jUserDraft')]"
+              },
+              {
+                "name": "Neo4j__Endpoints__0__Password",
+                "value": "[parameters('Neo4jPasswordDraft')]"
+              }
+            ]
+          }
+        }
+      },
+      "dependsOn": [
+        "[parameters('FunctionAppInsightNameDraft')]"
       ]
     }
   ],

--- a/Resources/ArmTemplates/test-parameters.json
+++ b/Resources/ArmTemplates/test-parameters.json
@@ -44,6 +44,15 @@
     "Neo4jPassword": {
       "value": "not-a-real-password"
     },
+    "Neo4jUrlDraft": {
+      "value": "http://some-database-instance/"
+    },
+    "Neo4jUserDraft": {
+      "value": "someUsername"
+    },
+    "Neo4jPasswordDraft": {
+      "value": "not-a-real-password"
+    },
     "appSharedStorageAccountName": {
       "value": "dfcdevappsharedstr"
     },

--- a/Resources/ArmTemplates/test-parameters.json
+++ b/Resources/ArmTemplates/test-parameters.json
@@ -2,6 +2,9 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "Environment": {
+      "value": "dev"
+    },
     "appSharedResourceGroup": {
       "value": "dfc-dev-app-sharedresources-rg"
     },
@@ -20,8 +23,14 @@
     "FunctionAppName": {
       "value": "dfc-dev-funcapp-v1-fa"
     },
+    "FunctionAppNameDraft": {
+      "value": "dfc-dev-funcappdraft-v1-fa"
+    },
     "FunctionAppInsightName": {
       "value": "dfc-dev-funcapp-v1-ai"
+    },
+    "FunctionAppInsightNameDraft": {
+      "value": "dfc-dev-funcappdraft-v1-ai"
     },
     "ApimProductInstanceName": {
       "value": "test-api-product"

--- a/Resources/ArmTemplates/test-parameters.json
+++ b/Resources/ArmTemplates/test-parameters.json
@@ -67,12 +67,6 @@
     },
     "ApiName": {
       "value": "api-name"
-    },
-    "ApiVersionNumber": {
-      "value": "v1"
-    },
-    "ApimLoggerName": {
-      "value": "some-apim-logger"
     }
   }
 }

--- a/Resources/AzureDevOps/azure-pipelines.yml
+++ b/Resources/AzureDevOps/azure-pipelines.yml
@@ -153,3 +153,5 @@ stages:
         -
           - name: GetContent
             azureFunctionName: '${{ variables.WebAppPrefix }}-api-cont-fa'
+          - name: GetDraftContent
+            azureFunctionName: '${{ variables.WebAppPrefix }}-api-draftcont-fa'

--- a/Resources/AzureDevOps/azure-pipelines.yml
+++ b/Resources/AzureDevOps/azure-pipelines.yml
@@ -68,7 +68,7 @@ stages:
   variables:
   - template: VariableTemplates/DevEnvironmentVariables.yml
   - group: dfc-shared-all
-  - group: dfc-api-content-all
+  - group: dfc-api-content-dev
   - group: dfc-app-integrationtests-all
   - group: dfc-shared-dev
   - group: dfc-app-shared-all

--- a/Resources/AzureDevOps/azure-pipelines.yml
+++ b/Resources/AzureDevOps/azure-pipelines.yml
@@ -106,6 +106,8 @@ stages:
         -
           - name: GetContent
             azureFunctionName: '${{ variables.WebAppPrefix }}-api-cont-fa'
+          - name: GetDraftContent
+            azureFunctionName: '${{ variables.WebAppPrefix }}-api-draftcont-fa'
 
 - stage: DeployToSitContent
   condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))


### PR DESCRIPTION
- Added new function app for draft content + associated params
- Added GetDraftContent API
- Added DFC.Api.Content/OpenAPIDocs/GetDraftContentOpenApi.txt
- Added params for new neo4j instance
- Added environment param and fixed hardcoded "dev" in resourcePrefix
- Renamed var group dfc-api-content-all to dfc-api-content-dev and changed in Devops
- Removed unused ApiVersionNumber and ApimLoggerName params